### PR TITLE
Creación del Modulo Tipo Producto

### DIFF
--- a/app/Http/Controllers/TipoProductoController.php
+++ b/app/Http/Controllers/TipoProductoController.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\TipoProducto;
+
+class TipoProductoController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index()
+    {
+        $tipos = TipoProducto::orderBy('nombre')->get();
+        $tiposProductos = TipoProducto::paginate(10);  // Paginación de 10 elementos por página
+        return view('tipo_productos.index', compact('tiposProductos'));
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     */
+    public function create()
+    {
+        return view('tipo_productos.create');
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request)
+    {
+        $request->validate([
+            'nombre' => 'required|string|max:100|unique:tipo_productos,nombre',
+            'descripcion' => 'nullable|string|max:255',
+        ]);
+
+        TipoProducto::create([
+            'nombre' => $request->nombre,
+            'descripcion' => $request->descripcion,
+            'estado' => true,
+        ]);
+
+        return redirect()->route('tipo_productos.index')->with('success', 'Tipo de producto creado correctamente');
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(string $id)
+    {
+        $tipo = TipoProducto::with('productos')->findOrFail($id);
+        $productos = $tipo->productos()->paginate(10); // Paginación de 10 por página
+        return view('tipo_productos.show', compact('tipo'));
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     */
+    public function edit(string $id)
+    {
+        $tipo = TipoProducto::findOrFail($id);
+        return view('tipo_productos.edit', compact('tipo'));
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, string $id)
+    {
+        $tipo = TipoProducto::findOrFail($id);
+
+        $request->validate([
+            'nombre' => 'required|string|max:100|unique:tipo_productos,nombre,' . $tipo->id,
+            'descripcion' => 'nullable|string|max:255',
+        ]);
+
+        $tipo->update([
+            'nombre' => $request->nombre,
+            'descripcion' => $request->descripcion,
+        ]);
+
+        return redirect()->route('tipo_productos.index')->with('success', 'Tipo de producto actualizado correctamente');
+    }
+
+    // Desactivar tipo de producto
+    public function desactivar($id)
+    {
+        $tipo = TipoProducto::findOrFail($id);
+        $tipo->estado = 0;
+        $tipo->save();
+
+        return redirect()->route('tipo_productos.index')->with('success', 'Tipo de producto desactivado correctamente.');
+    }
+
+    // Activar tipo de producto
+    public function activar($id)
+    {
+        $tipo = TipoProducto::findOrFail($id);
+        $tipo->estado = 1;
+        $tipo->save();
+
+        return redirect()->route('tipo_productos.index')->with('success', 'Tipo de producto activado correctamente.');
+    }
+}

--- a/app/Models/TipoProducto.php
+++ b/app/Models/TipoProducto.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class TipoProducto extends Model
+{
+    protected $table = 'tipo_productos';
+
+    protected $fillable = [
+        'nombre',
+        'descripcion',
+        'activo'
+    ];
+
+    // Relación con productos --Descomentar en el futuro
+    // public function productos() {
+    //     return $this->hasMany(Producto::class);
+    // }
+
+    
+}

--- a/database/migrations/2025_05_01_174513_create_tipo_productos_table.php
+++ b/database/migrations/2025_05_01_174513_create_tipo_productos_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up()
+    {
+        Schema::create('tipo_productos', function (Blueprint $table) {
+            $table->id();
+            $table->string('nombre')->unique();
+            $table->text('descripcion')->nullable();
+            $table->boolean('estado')->default(true);
+            $table->timestamps();
+        });
+    }
+    
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('tipo_productos');
+    }
+};

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -57,6 +57,12 @@
                                             <i class="fa-solid fa-tags"></i> <!-- Icono para Categorías -->
                                             <span class="ml-3">{{ __('Categorías') }}
                                         </x-dropdown-link>
+
+                                        <!-- Enlace a Tipos de Productos -->
+                                        <x-dropdown-link :href="route('tipo_productos.index')" :active="request()->routeIs('tipo_productos.*')">
+                                            <i class="fa-solid fa-box"></i> <!-- Icono para Tipos de Productos -->
+                                            <span class="ml-3">{{ __('Tipos de Productos') }}</span>
+                                        </x-dropdown-link>
                                     </x-slot>
                                 </x-dropdown>
                             </div>

--- a/resources/views/tipo_productos/create.blade.php
+++ b/resources/views/tipo_productos/create.blade.php
@@ -1,0 +1,35 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="text-xl font-semibold leading-tight text-gray-800 dark:text-gray-100">
+            Crear Tipo de Producto
+        </h2>
+    </x-slot>
+
+    <div class="py-6">
+        <div class="mx-auto max-w-3xl sm:px-6 lg:px-8">
+            <div class="rounded bg-white dark:bg-gray-800 p-6 shadow">
+                <form method="POST" action="{{ route('tipo_productos.store') }}">
+                    @csrf
+
+                    <div class="mb-4">
+                        <x-input-label for="nombre" value="Nombre del Tipo" />
+                        <x-text-input id="nombre" name="nombre" type="text" class="w-full"
+                            value="{{ old('nombre') }}" required autofocus />
+                        <x-input-error :messages="$errors->get('nombre')" class="mt-1 text-sm text-red-600 dark:text-red-400" />
+                    </div>
+
+                    <div class="mt-4">
+                        <x-primary-button>
+                            Crear Tipo
+                        </x-primary-button>
+                        <a href="{{ route('tipo_productos.index') }}" class="ml-4 text-blue-500 hover:text-blue-700">
+                            Volver
+                        </a>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</x-app-layout>
+
+<!-- I begin to speak only when I am certain what I will say is not better left unsaid. - Cato the Younger -->

--- a/resources/views/tipo_productos/edit.blade.php
+++ b/resources/views/tipo_productos/edit.blade.php
@@ -1,0 +1,36 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="text-xl font-semibold leading-tight text-gray-800 dark:text-gray-100">
+            Editar Tipo de Producto
+        </h2>
+    </x-slot>
+
+    <div class="py-6">
+        <div class="mx-auto max-w-xl sm:px-6 lg:px-8">
+            <div class="bg-white dark:bg-gray-800 p-6 shadow rounded">
+                <form method="POST" action="{{ route('tipo_productos.update', $tipo->id) }}">
+                    @csrf
+                    @method('PUT')
+
+                    <div class="mb-4">
+                        <x-input-label for="nombre" value="Nombre del Tipo" />
+                        <x-text-input id="nombre" name="nombre" type="text" class="w-full"
+                            value="{{ old('nombre', $tipo->nombre) }}" required />
+                        <x-input-error :messages="$errors->get('nombre')" class="mt-1 text-sm text-red-600 dark:text-red-400" />
+                    </div>
+
+                    <div class="mt-4">
+                        <x-primary-button>
+                            Actualizar
+                        </x-primary-button>
+                        <a href="{{ route('tipo_productos.index') }}" class="ml-4 text-blue-500 hover:text-blue-700">
+                            Cancelar
+                        </a>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</x-app-layout>
+
+<!-- Do what you can, with what you have, where you are. - Theodore Roosevelt -->

--- a/resources/views/tipo_productos/index.blade.php
+++ b/resources/views/tipo_productos/index.blade.php
@@ -1,0 +1,75 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="text-xl font-semibold leading-tight text-gray-800 dark:text-gray-100">
+            {{ __('Tipo de Productos') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-6">
+        <div class="mx-auto max-w-7xl sm:px-6 lg:px-8">
+            <a href="{{ route('tipo_productos.create') }}"
+                class="mb-4 inline-block rounded bg-blue-500 px-4 py-2 text-white hover:bg-blue-600">
+                <i class="fa-solid fa-square-plus"></i> Crear Tipo de Producto
+            </a>
+            @if (session('success'))
+                <div class="mb-4 rounded bg-green-100 p-4 text-green-800 dark:text-green-300 dark:bg-green-900/20">
+                    {{ session('success') }}
+                </div>
+            @endif
+            <div class="overflow-x-auto rounded bg-white dark:bg-gray-800 p-4 shadow dark:shadow-md">
+                <table class="w-full table-auto text-left text-sm text-gray-800 dark:text-gray-100">
+                    <thead>
+                        <tr>
+                            <th class="border-b p-2">Nombre</th>
+                            <th class="border-b p-2">Estado</th>
+                            <th class="border-b p-2">Acciones</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach ($tiposProductos as $tipo)
+                            <tr>
+                                <td class="border-b p-2">{{ $tipo->nombre }}</td>
+                                <td class="border-b p-2">
+                                    <span class="{{ $tipo->estado ? 'text-green-600' : 'text-red-600' }}">
+                                        {{ $tipo->estado ? 'Activo' : 'Inactivo' }}
+                                    </span>
+                                </td>
+                                <td class="border-b p-2 space-x-2">
+                                    <a href="{{ route('tipo_productos.show', $tipo->id) }}"
+                                        class="text-gray-600 dark:text-gray-300 hover:underline">Ver</a>
+                                    <a href="{{ route('tipo_productos.edit', $tipo->id) }}"
+                                        class="text-blue-500 hover:underline">Editar</a>
+
+                                    @if ($tipo->estado)
+                                        <form method="POST"
+                                            action="{{ route('tipo_productos.desactivar', $tipo->id) }}" class="inline">
+                                            @csrf
+                                            @method('PATCH')
+                                            <button type="submit"
+                                                class="text-red-500 hover:underline">Desactivar</button>
+                                        </form>
+                                    @else
+                                        <form method="POST" action="{{ route('tipo_productos.activar', $tipo->id) }}"
+                                            class="inline">
+                                            @csrf
+                                            @method('PATCH')
+                                            <button type="submit"
+                                                class="text-green-500 hover:underline">Activar</button>
+                                        </form>
+                                    @endif
+                                </td>
+
+                            </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+
+                <!-- Paginación -->
+                <div class="mt-4">
+                    {{ $tiposProductos->links() }} <!-- Esto generará los enlaces de paginación -->
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>
+<!-- Simplicity is the consequence of refined emotions. - Jean D'Alembert -->

--- a/resources/views/tipo_productos/show.blade.php
+++ b/resources/views/tipo_productos/show.blade.php
@@ -1,0 +1,89 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="text-xl font-semibold leading-tight text-gray-800 dark:text-gray-100">
+            Detalle del Tipo de Producto: {{ $tipo->nombre }}
+        </h2>
+    </x-slot>
+
+    <div class="py-6">
+        <div class="mx-auto max-w-6xl sm:px-6 lg:px-8">
+            <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg p-6">
+                {{-- Aquí va la info del tipo de producto --}}
+                <div class="mb-6">
+                    <h3 class="text-lg font-bold mb-2">Información del Tipo</h3>
+                    <p><strong>Nombre:</strong> {{ $tipo->nombre }}</p>
+                    <p>
+                        <strong>Estado:</strong>
+                        <span class="{{ $tipo->estado ? 'text-green-600' : 'text-red-600' }}">
+                            {{ $tipo->estado ? 'Activo' : 'Inactivo' }}
+                        </span>
+                    </p>
+
+                    {{-- Botones --}}
+                    <div class="mt-4 flex gap-3">
+                        <a href="{{ route('tipo_productos.edit', $tipo->id) }}"
+                            class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700">
+                            Editar
+                        </a>
+
+                        @if ($tipo->estado)
+                            <form action="{{ route('tipo_productos.desactivar', $tipo->id) }}" method="POST">
+                                @csrf
+                                <button type="submit" class="px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700">
+                                    Desactivar
+                                </button>
+                            </form>
+                        @else
+                            <form action="{{ route('tipo_productos.activar', $tipo->id) }}" method="POST">
+                                @csrf
+                                <button type="submit"
+                                    class="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700">
+                                    Activar
+                                </button>
+                            </form>
+                        @endif
+                    </div>
+                </div>
+
+                {{-- Tabla de productos --}}
+                <div class="bg-white shadow p-4 rounded">
+                    <h3 class="text-xl font-bold mb-4">Productos Asociados</h3>
+                    @if ($productos->count())
+                        <table class="w-full table-auto border-collapse">
+                            <thead>
+                                <tr class="bg-gray-100 text-left">
+                                    <th class="p-2">Nombre</th>
+                                    <th class="p-2">Código</th>
+                                    <th class="p-2">Stock</th>
+                                    <th class="p-2">Estado</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach ($productos as $producto)
+                                    <tr class="border-t">
+                                        <td class="p-2">{{ $producto->nombre }}</td>
+                                        <td class="p-2">{{ $producto->codigo }}</td>
+                                        <td class="p-2">{{ $producto->stock }}</td>
+                                        <td class="p-2">
+                                            <span class="{{ $producto->estado ? 'text-green-600' : 'text-red-600' }}">
+                                                {{ $producto->estado ? 'Activo' : 'Inactivo' }}
+                                            </span>
+                                        </td>
+                                    </tr>
+                                @endforeach
+                            </tbody>
+                        </table>
+
+                        <div class="mt-4">
+                            {{ $productos->links() }}
+                        </div>
+                    @else
+                        <p class="text-gray-500">No hay productos asociados a este tipo.</p>
+                    @endif
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>
+
+<!-- It is never too late to be what you might have been. - George Eliot -->

--- a/routes/web.php
+++ b/routes/web.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\CiudadController;
 use App\Http\Controllers\UserController;
 use App\Http\Controllers\ServicioController;
 use App\Http\Controllers\CategoriaController;
+use App\Http\Controllers\TipoProductoController;
 
 // Rutas de categorías
 Route::resource('servicios', ServicioController::class);
@@ -54,6 +55,9 @@ Route::get('/categorias/inactivas', [CategoriaController::class, 'inactivas'])->
 
 Route::resource('categorias', CategoriaController::class)->except(['destroy']);
 
+Route::patch('tipo_productos/{id}/desactivar', [TipoProductoController::class, 'desactivar'])->name('tipo_productos.desactivar');
+Route::patch('tipo_productos/{id}/activar', [TipoProductoController::class, 'activar'])->name('tipo_productos.activar');
+Route::resource('tipo_productos', TipoProductoController::class)->except(['destroy']);
 
 
 

--- a/storage/framework/views/71ca4f8d0b5fa011e65b8e3781038598.php
+++ b/storage/framework/views/71ca4f8d0b5fa011e65b8e3781038598.php
@@ -176,6 +176,30 @@
 <?php $component = $__componentOriginal68cb1971a2b92c9735f83359058f7108; ?>
 <?php unset($__componentOriginal68cb1971a2b92c9735f83359058f7108); ?>
 <?php endif; ?>
+
+                                        <!-- Enlace a Tipos de Productos -->
+                                        <?php if (isset($component)) { $__componentOriginal68cb1971a2b92c9735f83359058f7108 = $component; } ?>
+<?php if (isset($attributes)) { $__attributesOriginal68cb1971a2b92c9735f83359058f7108 = $attributes; } ?>
+<?php $component = Illuminate\View\AnonymousComponent::resolve(['view' => 'components.dropdown-link','data' => ['href' => route('tipo_productos.index'),'active' => request()->routeIs('tipo_productos.*')]] + (isset($attributes) && $attributes instanceof Illuminate\View\ComponentAttributeBag ? $attributes->all() : [])); ?>
+<?php $component->withName('dropdown-link'); ?>
+<?php if ($component->shouldRender()): ?>
+<?php $__env->startComponent($component->resolveView(), $component->data()); ?>
+<?php if (isset($attributes) && $attributes instanceof Illuminate\View\ComponentAttributeBag): ?>
+<?php $attributes = $attributes->except(\Illuminate\View\AnonymousComponent::ignoredParameterNames()); ?>
+<?php endif; ?>
+<?php $component->withAttributes(['href' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute(route('tipo_productos.index')),'active' => \Illuminate\View\Compilers\BladeCompiler::sanitizeComponentAttribute(request()->routeIs('tipo_productos.*'))]); ?>
+                                            <i class="fa-solid fa-box"></i> <!-- Icono para Tipos de Productos -->
+                                            <span class="ml-3"><?php echo e(__('Tipos de Productos')); ?></span>
+                                         <?php echo $__env->renderComponent(); ?>
+<?php endif; ?>
+<?php if (isset($__attributesOriginal68cb1971a2b92c9735f83359058f7108)): ?>
+<?php $attributes = $__attributesOriginal68cb1971a2b92c9735f83359058f7108; ?>
+<?php unset($__attributesOriginal68cb1971a2b92c9735f83359058f7108); ?>
+<?php endif; ?>
+<?php if (isset($__componentOriginal68cb1971a2b92c9735f83359058f7108)): ?>
+<?php $component = $__componentOriginal68cb1971a2b92c9735f83359058f7108; ?>
+<?php unset($__componentOriginal68cb1971a2b92c9735f83359058f7108); ?>
+<?php endif; ?>
                                      <?php $__env->endSlot(); ?>
                                  <?php echo $__env->renderComponent(); ?>
 <?php endif; ?>


### PR DESCRIPTION
# 🚀 Gestión de Tipos de Productos

Este Pull Request implementa la funcionalidad completa del módulo **Tipo de Productos** en el sistema GOTIM. Se incluye la creación, edición, visualización, listado y desactivación lógica de tipos de productos.

---

## ✅ Cambios realizados

- **CRUD completo de Tipos de Productos**:
  - `index`: listado con paginación y acciones.
  - `create`: formulario para agregar nuevo tipo.
  - `edit`: edición de nombre del tipo.
  - `show`: visualización de detalles + productos asociados.

- **Eliminación lógica**:
  - Se utiliza el campo `estado` (`1` activo, `0` inactivo).
  - Tipos desactivados pueden reactivarse.
  - Se agregan botones condicionales para activar/desactivar según estado.

- **Rutas nuevas**:
  - `PATCH /tipo_productos/{id}/desactivar` → Desactiva tipo de producto.
  - `PATCH /tipo_productos/{id}/activar` → Reactiva tipo de producto.
  - Se usa `Route::resource` sin `destroy`.

- **Mejoras visuales**:
  - Se integran estilos con `x-app-layout` y alertas de éxito.
  - Uso de íconos, colores de acción y tablas responsivas.

- **Paginación funcional**:
  - Corregido error de `links()` usando `paginate()` en lugar de `get()`.

---

## ✅ Readme para la creación de Productos

- La tabla `productos` debe tener una FK: `tipo_producto_id` (nullable, esto para no tener la obligación de agregarlo a un tipo).
- Cada producto pertenece a un `TipoProducto`.
-  En los formularios (crear/editar producto), **solo deben mostrarse tipos de producto con `estado = 1`**.
-  Si un producto ya tiene asignado un tipo que fue desactivado, **se mantiene la relación**, pero ese tipo no debe estar disponible para nuevas asignaciones.
- Solo deben listarse tipos activos en los formularios.
